### PR TITLE
update: change file and the name of CAPA in Phoenix

### DIFF
--- a/cosmos/phoenix/tokens/terra1t4p3u8khpd7f8qzurwyafxt648dya6mp6vur3vaapswt6m24gkuqrfdhar.json
+++ b/cosmos/phoenix/tokens/terra1t4p3u8khpd7f8qzurwyafxt648dya6mp6vur3vaapswt6m24gkuqrfdhar.json
@@ -2,7 +2,7 @@
   "contractAddress": "terra1t4p3u8khpd7f8qzurwyafxt648dya6mp6vur3vaapswt6m24gkuqrfdhar",
   "imageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-contract-registry/main/images/phoenix/Capapult.png",
   "metadata": {
-    "name": "Capapult governance token",
+    "name": "Capa",
     "symbol": "CAPA",
     "decimals": 6
   }


### PR DESCRIPTION
update: change file and the name of CAPA from "Capapult Governance Token" to "Capa" in Phoenix